### PR TITLE
Add expectedOption['data'] to allow probe to perform post of data

### DIFF
--- a/src/PhpProbe/Adapter/PhpCurlAdapter.php
+++ b/src/PhpProbe/Adapter/PhpCurlAdapter.php
@@ -75,5 +75,8 @@ class PhpCurlAdapter extends AbstractAdapter implements AdapterInterface
             curl_setopt($curlHandler, CURLOPT_SSL_VERIFYHOST, 0);
             curl_setopt($curlHandler, CURLOPT_SSL_VERIFYPEER, false);
         }
+        if (!empty($parameters['data'])) {
+            curl_setopt($curlHandler, CURLOPT_POSTFIELDS, json_encode($parameters['data']));
+        }
     }
 }

--- a/src/PhpProbe/Probe/HttpProbe.php
+++ b/src/PhpProbe/Probe/HttpProbe.php
@@ -24,7 +24,8 @@ class HttpProbe extends AbstractProbe implements ProbeInterface
         'url'      => array('name' => 'url', 'required' => true, 'type' => 'string'),
         'timeout'  => array('name' => 'timeout', 'required' => true, 'type' => 'integer', 'default' => 2),
         'headers'  => array('name' => 'headers', 'required' => true, 'type' => 'array', 'default' => array()),
-        'unsecure' => array('name' => 'unsecure', 'required' => true, 'type' => 'boolean', 'default' => false)
+        'unsecure' => array('name' => 'unsecure', 'required' => true, 'type' => 'boolean', 'default' => false),
+        'data'     => array('name' => 'data', 'required' => false, 'type' => 'array', 'default' => array())
     );
 
     /**


### PR DESCRIPTION
Added the ability to perform a data post as part of an http probe. Allowing the ability to probe a RESTAPI to ensure that it is both available and returning a response within an except able time frame.

**Example from config.yaml**
```
  REST.API_HTTPS:
    type: Http
    options:
      unsecure: false
      url: https://foo.bar.com/getafoo
      data:
        fooid: 3
      timeout: 2
    checkers:
      http:
        httpCode: 200
      generic:
        responseTime: 2
  Another_REST.API_HTTPS:
    type: Http
    options:
      unsecure: false
      url: https://foo.bar.com/getdetailedfoo
      data:
        footype: purple
        foosize: small
      timeout: 2
    checkers:
      http:
        httpCode: 200
      generic:
        responseTime: 2
```
**JSON Data**  
```
<!-- Probe 1 -->
{ "fooid" : "2" }
<!-- Probe 2 -->
{ "footype" : "purple", "foosize" : "small" }
```